### PR TITLE
run.sh helper script to run install tasks easier

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker run -w=/var/www -v $PWD:/var/www -p 80:80 -ti php:7.4-apache-xdebug "$@"


### PR DESCRIPTION
`./run.sh` without any arguments will just host application in docker php:7.4-apache-xdebug
if provided with arguments will execute them inside docker container in project directory
E.g. `./run.sh composer install` will run `composer install` inside project folder in docker container